### PR TITLE
Fix the "patch" CodeLens button

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -9,9 +9,8 @@
             "args": [
                 "--extensionDevelopmentPath=${workspaceFolder}"
             ],
-            "stopOnEntry": false,
             "sourceMaps": true,
-            "outFiles": [ "${workspaceRoot}/out/src/**/*.js" ],
+            "outFiles": [ "${workspaceRoot}/out/**/*.js" ],
             "preLaunchTask": "npm: build",
         }
     ]

--- a/src/Mod.ts
+++ b/src/Mod.ts
@@ -85,7 +85,7 @@ export default class Mod {
                         const choice = await vscode.window.showErrorMessage('An error occurred while compiling the mod.', 'View Log')
                         if (choice === 'View Log') {
                             const doc = await vscode.workspace.openTextDocument(this.uri.with({
-                                path: this.uri.path + '/logs/compile.log',
+                                path: starRodDir.fsPath + '/logs/compile.log',
                             }))
                             await vscode.window.showTextDocument(doc)
                         }

--- a/src/StarRodCodeLensProvider.ts
+++ b/src/StarRodCodeLensProvider.ts
@@ -34,6 +34,7 @@ export default class StarRodCodeLensProvider implements vscode.CodeLensProvider 
                         snippet.appendPlaceholder(stripOffsets(directive.block?.replace(/^\r?\n/, '') ?? ''))
                         snippet.appendText('}')
                         snippet.appendText('\n')
+                        snippet.appendText('\n')
                         lenses.push(new CodeLens(directive.range, {
                             title: 'Patch',
                             command: 'starRod.codeLens.insertPatchSnippet',
@@ -105,7 +106,7 @@ export function activate(ctx: ExtensionContext): void {
 
         const editor = await vscode.window.showTextDocument(document)
 
-        editor.insertSnippet(snippet, new Position(document.lineCount + 2, 0))
+        editor.insertSnippet(snippet, new Position(document.lineCount-1, 0))
     }))
 
     ctx.subscriptions.push(vscode.commands.registerCommand('starRod.codeLens.openScript', async (script: Script) => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,6 +9,7 @@
         ],
         "resolveJsonModule": true,
         "sourceMap": true,
+        "inlineSources": true,
         "rootDir": "src",
         "strict": true,
         "noImplicitReturns": true,


### PR DESCRIPTION
The `insertSnippet` method was trying to write outside the line bounds of the newly opened file, which doesn't work. This fix leaves it up to the end user to make the resulting mpat file look nice.